### PR TITLE
Add Environments "testzurkontrolle" and "testszurkontrolle"

### DIFF
--- a/tex/algo-common.sty
+++ b/tex/algo-common.sty
@@ -387,6 +387,8 @@
     \rubosDeclareColorBoxEnvironment*{kaufgaben}{infoBox}{Konkrete~Aufgaben}
     \rubosDeclareColorBoxEnvironment*{tldr}{infoBox}{Tl;dr}
     \rubosDeclareColorBoxEnvironment*{tldr}{infoBox}{Tl;dr}
+    \rubosDeclareColorBoxEnvironment{testzurkontrolle}{grayInfoBox}{Unbewerteter~Test~zur~eigenen~Kontrolle}
+    \rubosDeclareColorBoxEnvironment{testszurkontrolle}{grayInfoBox}{Unbewertete~Tests~zur~eigenen~Kontrolle}
     \rubosDeclareColorBoxEnvironment{vfrage}{grayInfoBox}{Unbewertete~Verständnisfrage}
     \rubosDeclareColorBoxEnvironment*[0~Punkte]{wvfrage}{grayInfoBox}{Wichtige~Verständnisfrage}
     \rubosDeclareColorBoxEnvironment{vfragen}{grayInfoBox}{Unbewertete~Verständnisfragen}


### PR DESCRIPTION
Both environments are using the basic gray definition environment. `testzurkontrolle` uses "Unbewerteter Test zur eigenen Kontrolle" as title (for singular test), `testszurkontrolle` uses "Unbewertete Tests zur eigenen Kontrolle" as title (for multiple tests).