### PR TITLE
Add a Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697793076,
+        "narHash": "sha256-02e7sCuqLtkyRgrZmdOyvAcQTQdcXj+vpyp9bca6cY4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "038b2922be3fc096e1d456f93f7d0f4090628729",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,9 +31,8 @@
           inherit algotex;
         };
     in {
-      devShells.${system}.default = with pkgs; mkShell {
-        buildInputs = [ python311Packages.pygments patched-latex ];
-      };
+      devShells.${system}.default = with pkgs;
+        mkShell { buildInputs = [ python311Packages.pygments patched-latex ]; };
       packages.${system}.default = patched-latex;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "AlgoTeX flake";
+
+  outputs = { self, nixpkgs, }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      algotex = with pkgs;
+        stdenvNoCC.mkDerivation (finalAttrs: {
+          name = "algotex";
+          src = fetchFromGitHub {
+            owner = "tudalgo";
+            repo = "AlgoTeX";
+            rev = "5f0d8bd394bba5b04eef0d11614b3cadd315f1c8";
+            hash = "sha256-hpuPeK1xj62xveMBh8X1NvRKgtRTSUBZk5eOPixxIpY=";
+          };
+          passthru = {
+            pkgs = [ finalAttrs.finalPackage ];
+            tlType = "run";
+            tlDeps = with texlive; [ latex ];
+          };
+          installPhase = ''
+            mkdir -p $out/tex/latex/algotex
+            cp -t $out/tex/latex/algotex/ $src/tex/*
+            mv $out/tex/latex/algotex/FOPBot.sty $out/tex/latex/algotex/fopbot.sty
+          '';
+        });
+      patched-latex = with pkgs.texlive;
+        combine {
+          inherit scheme-full;
+          inherit algotex;
+        };
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [ pkgs.python311Packages.pygments patched-latex ];
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,8 +31,8 @@
           inherit algotex;
         };
     in {
-      devShells.${system}.default = pkgs.mkShell {
-        buildInputs = [ pkgs.python311Packages.pygments patched-latex ];
+      devShells.${system}.default = with pkgs; mkShell {
+        buildInputs = [ python311Packages.pygments patched-latex ];
       };
       packages.${system}.default = patched-latex;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           installPhase = ''
             mkdir -p $out/tex/latex/algotex
             cp -t $out/tex/latex/algotex/ $src/tex/*
-            mv $out/tex/latex/algotex/FOPBot.sty $out/tex/latex/algotex/fopbot.sty
+            cp $out/tex/latex/algotex/FOPBot.sty $out/tex/latex/algotex/fopbot.sty
           '';
         });
       patched-latex = with pkgs.texlive;

--- a/flake.nix
+++ b/flake.nix
@@ -34,5 +34,6 @@
       devShells.${system}.default = pkgs.mkShell {
         buildInputs = [ pkgs.python311Packages.pygments patched-latex ];
       };
+      packages.${system}.default = patched-latex;
     };
 }

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,14 @@ Die Vorlage wurde für LuaLaTeX geschrieben, ist aber dank des Latex3-Kernels au
 ## Installation
 
 ### Automatisch
+#### Nix
+Für Nutzer des Paketmanagers Nix und/oder der Distribution NixOS wird eine `flake.nix`-Datei bereitgestellt.
+
+Diese enthält eine `default`-Shell, welche alle benötigten Abhängigkeiten enthält und über den Befehl `nix develop` gestartet werden kann. Beachten Sie, dass hierfür Nix-Flakes [aktiviert](https://nixos.wiki/wiki/Flakes#Enable_flakes) sein müssen.
+
+Über den `packages.x86_64-linux.default`-Output kann über eine `nixpkgs.texlive.combined.scheme-full-`Derivation verfügt werden, die zusätzlich die AlgoTeX-Vorlage enthält. Bitte beachten Sie, dass das Paket `nixpkgs.python311Packages.pygments` o.Ä. zusätzlich benötigt wird.
+
+#### Arch-basierende Linux-Distributionen
 Für Arch-basierende Linux-Distributionen wird das Paket [`algotex-git`](https://aur.archlinux.org/packages/algotex-git) im [`AUR`](https://aur.archlinux.org/) bereitgestellt.
 
 ### Manuell
@@ -65,7 +73,7 @@ Dazu kann man den [`tex`](tex/)-Ordner verlinken:
 git clone https://github.com/TUDalgo/AlgoTeX.git
 cd AlgoTeX
 mkdir -p "$(kpsewhich -var-value=TEXMFHOME)/tex/latex/AlgoTeX"
-# Ordner Verlinkrn
+# Verzeichnis verlinken
 ln -s "$(pwd)/tex" "$(kpsewhich -var-value=TEXMFHOME)/tex/latex/AlgoTeX"
 sudo texhash "$(kpsewhich -var-value=TEXMFHOME)"
 ```


### PR DESCRIPTION
This pr aims to add a Nix flake to the template.
It aims to provide:
- A shell to use with `nix develop`
- A usable package that contains a patched version of `nixpkgs.texlive.combined.scheme-full`