### PR TITLE
Add support for ARM64 architecture in Docker build and push action

### DIFF
--- a/.github/workflows/docker-img.yml
+++ b/.github/workflows/docker-img.yml
@@ -70,3 +70,4 @@ jobs:
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/docker-img.yml
+++ b/.github/workflows/docker-img.yml
@@ -70,4 +70,4 @@ jobs:
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64/v8
+          platforms: linux/amd64, linux/arm64

--- a/.github/workflows/docker-img.yml
+++ b/.github/workflows/docker-img.yml
@@ -36,6 +36,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container registry
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -62,6 +63,7 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
This PR updates the Docker build and push action to include the `linux/arm64` platform in addition to `linux/amd64`. Previously, the build configuration only targeted `amd64`, which made it impossible to pull the image on Macs with ARM architecture chips.

With this change, the Docker images will be built for both `amd64` and `arm64` architectures, ensuring compatibility across a wider range of devices, including ARM-based Macs.

